### PR TITLE
Creates interface to communicate with other mods and menus optional

### DIFF
--- a/Client/CoopClient.csproj
+++ b/Client/CoopClient.csproj
@@ -19,7 +19,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x64</PlatformTarget>
@@ -65,6 +65,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Chat.cs" />
+    <Compile Include="Interface.cs" />
     <Compile Include="Entities\EntitiesNpc.cs" />
     <Compile Include="Entities\EntitiesPed.cs" />
     <Compile Include="Entities\EntitiesPlayer.cs" />

--- a/Client/Interface.cs
+++ b/Client/Interface.cs
@@ -1,0 +1,44 @@
+﻿using Lidgren.Network;
+
+namespace CoopClient
+{
+    public static class Interface
+    {
+        public delegate void ConnectEvent(bool connected, string bye_message);
+        public static event ConnectEvent OnConnect;
+        public static event ConnectEvent OnDisconnect;
+        public delegate void MessageEvent(NetIncomingMessage message);
+        public static event MessageEvent OnMessage;
+
+        public static void Connect(string serverAddress)
+        {
+            Main.MainNetworking.DisConnectFromServer(serverAddress);
+        }
+
+        public static void Configure(string playerName, bool shareNpcsWithPlayers, int streamedNpcs, bool debug = false)
+        {
+            Main.MainSettings.Username = playerName;
+            Main.ShareNpcsWithPlayers = shareNpcsWithPlayers;
+            Main.MainSettings.StreamedNpc = streamedNpcs;
+#if DEBUG
+            Main.UseDebug = debug;
+#endif
+        }
+
+        public static void Disconnected( string bye_message)
+        {
+            OnDisconnect?.Invoke(false, bye_message);
+        }
+
+        public static void Connected()
+        {
+            OnConnect?.Invoke(true, "");
+        }
+
+        public static void MessageReceived(NetIncomingMessage message)
+        {
+            OnMessage?.Invoke(message);
+        }
+
+    }
+}

--- a/Client/Main.cs
+++ b/Client/Main.cs
@@ -26,11 +26,11 @@ namespace CoopClient
         private static bool IsGoingToCar = false;
 
         public static Settings MainSettings = Util.ReadSettings();
-
         public static Networking MainNetworking = new Networking();
 
+#if !NON_INTERACTIVE
         public static MenusMain MainMenu = new MenusMain();
-
+#endif
         public static Chat MainChat = new Chat();
 
         public static long LocalClientID = 0;
@@ -43,7 +43,9 @@ namespace CoopClient
             Function.Call((Hash)0x9BAE5AD2508DF078, true); // _ENABLE_MP_DLC_MAPS
 
             Tick += OnTick;
+#if !NON_INTERACTIVE
             KeyDown += OnKeyDown;
+#endif
             Aborted += (object sender, EventArgs e) => CleanUp();
 
             Util.NativeMemory();
@@ -62,7 +64,9 @@ namespace CoopClient
                 Game.Player.Character.RelationshipGroup = RelationshipGroup;
             }
 
+#if !NON_INTERACTIVE
             MainMenu.MenuPool.Process();
+#endif
 
             MainNetworking.ReceiveMessages();
 
@@ -110,6 +114,7 @@ namespace CoopClient
             LastDataSend = Environment.TickCount;
         }
 
+#if !NON_INTERACTIVE
         private void OnKeyDown(object sender, KeyEventArgs e)
         {
             if (MainChat.Focused)
@@ -169,6 +174,7 @@ namespace CoopClient
                     break;
             }
         }
+#endif
 
         public static void CleanUp()
         {

--- a/Client/Menus/MenusMain.cs
+++ b/Client/Menus/MenusMain.cs
@@ -68,5 +68,33 @@ namespace CoopClient.Menus
                 MenuPool.RefreshAll();
             }
         }
+
+        public void InitiateConnectionMenuSetting()
+        {
+            MainMenu.Items[0].Enabled = false;
+            MainMenu.Items[1].Enabled = false;
+            MainMenu.Items[2].Enabled = false;
+        }
+
+        public void ConnectedMenuSetting()
+        {
+            MainMenu.Items[2].Enabled = true;
+            MainMenu.Items[2].Title = "Disconnect";
+            SubSettings.MainMenu.Items[1].Enabled = !Main.DisableTraffic && Main.NpcsAllowed;
+
+            MainMenu.Visible = false;
+            MenuPool.RefreshAll();
+        }
+
+        public void DisconnectedMenuSetting()
+        {
+            MainMenu.Items[0].Enabled = true;
+            MainMenu.Items[1].Enabled = true;
+            MainMenu.Items[2].Enabled = true;
+            MainMenu.Items[2].Title = "Connect";
+            SubSettings.MainMenu.Items[1].Enabled = false;
+
+            MenuPool.RefreshAll();
+        }
     }
 }

--- a/Client/Menus/Sub/Settings.cs
+++ b/Client/Menus/Sub/Settings.cs
@@ -68,7 +68,9 @@ namespace CoopClient.Menus.Sub
 
         public void FlipMenuCheckboxChanged(object a, System.EventArgs b)
         {
+#if !NON_INTERACTIVE
             Main.MainMenu.MainMenu.Alignment = FlipMenuItem.Checked ? GTA.UI.Alignment.Right : GTA.UI.Alignment.Left;
+#endif
             MainMenu.Alignment = FlipMenuItem.Checked ? GTA.UI.Alignment.Right : GTA.UI.Alignment.Left;
 
             Main.MainSettings.FlipMenu = FlipMenuItem.Checked;

--- a/Client/Networking.cs
+++ b/Client/Networking.cs
@@ -28,8 +28,8 @@ namespace CoopClient
                 new PlayerDisconnectPacket() { ID = Main.LocalClientID }.PacketToNetOutGoingMessage(outgoingMessage);
                 Client.SendMessage(outgoingMessage, NetDeliveryMethod.ReliableOrdered);
                 Client.FlushSendQueue();
-
                 Client.Disconnect("Bye!");
+                Interface.Disconnected("Bye!");
             }
             else
             {
@@ -59,6 +59,7 @@ namespace CoopClient
                 }.PacketToNetOutGoingMessage(outgoingMessage);
 
                 Client.Connect(ip[0], short.Parse(ip[1]), outgoingMessage);
+                Interface.Connected();
             }
         }
 
@@ -90,9 +91,9 @@ namespace CoopClient
                         switch (status)
                         {
                             case NetConnectionStatus.InitiatedConnect:
-                                Main.MainMenu.MainMenu.Items[0].Enabled = false;
-                                Main.MainMenu.MainMenu.Items[1].Enabled = false;
-                                Main.MainMenu.MainMenu.Items[2].Enabled = false;
+#if !NON_INTERACTIVE
+                                Main.MainMenu.InitiateConnectionMenuSetting();
+#endif
                                 GTA.UI.Notification.Show("~y~Trying to connect...");
                                 break;
                             case NetConnectionStatus.Connected:
@@ -130,13 +131,9 @@ namespace CoopClient
                                     Client.FlushSendQueue();
 
                                     GTA.UI.Notification.Show("~g~Connected!");
-
-                                    Main.MainMenu.MainMenu.Items[2].Enabled = true;
-                                    Main.MainMenu.MainMenu.Items[2].Title = "Disconnect";
-                                    Main.MainMenu.SubSettings.MainMenu.Items[1].Enabled = !Main.DisableTraffic && Main.NpcsAllowed;
-
-                                    Main.MainMenu.MainMenu.Visible = false;
-                                    Main.MainMenu.MenuPool.RefreshAll();
+#if !NON_INTERACTIVE
+                                    Main.MainMenu.ConnectedMenuSetting();
+#endif
                                 }
                                 break;
                             case NetConnectionStatus.Disconnected:
@@ -153,14 +150,9 @@ namespace CoopClient
                                 }
 
                                 Main.CleanUp();
-
-                                Main.MainMenu.MainMenu.Items[0].Enabled = true;
-                                Main.MainMenu.MainMenu.Items[1].Enabled = true;
-                                Main.MainMenu.MainMenu.Items[2].Enabled = true;
-                                Main.MainMenu.MainMenu.Items[2].Title = "Connect";
-                                Main.MainMenu.SubSettings.MainMenu.Items[1].Enabled = false;
-
-                                Main.MainMenu.MenuPool.RefreshAll();
+#if !NON_INTERACTIVE
+                                Main.MainMenu.DisconnectedMenuSetting();
+#endif
                                 break;
                         }
                         break;
@@ -242,12 +234,13 @@ namespace CoopClient
                         break;
                 }
 
+                Interface.MessageReceived(message);
                 Client.Recycle(message);
             }
         }
 
-        #region -- GET --
-        #region -- PLAYER --
+#region -- GET --
+#region -- PLAYER --
         private void PlayerConnect(PlayerConnectPacket packet)
         {
             EntitiesPlayer player = new EntitiesPlayer()
@@ -448,9 +441,9 @@ namespace CoopClient
 
             Function.Call((Hash)packet.Hash, arguments.ToArray());
         }
-        #endregion // -- PLAYER --
+#endregion // -- PLAYER --
 
-        #region -- NPC --
+#region -- NPC --
         private void FullSyncNpc(FullSyncNpcPacket packet)
         {
             lock (Main.Npcs)
@@ -570,10 +563,10 @@ namespace CoopClient
                 }
             }
         }
-        #endregion // -- NPC --
-        #endregion
+#endregion // -- NPC --
+#endregion
 
-        #region -- SEND --
+#region -- SEND --
         private int LastPlayerFullSync = 0;
         public void SendPlayerData()
         {
@@ -792,6 +785,6 @@ namespace CoopClient
             }
 #endif
         }
-        #endregion
+#endregion
     }
 }

--- a/Client/PlayerList.cs
+++ b/Client/PlayerList.cs
@@ -33,7 +33,11 @@ namespace CoopClient
                 Update(Main.Players, Main.MainSettings.Username);
             }
 
-            if ((Environment.TickCount - Pressed) < 5000 && !Main.MainChat.Focused && !Main.MainMenu.MenuPool.AreAnyVisible)
+            if ((Environment.TickCount - Pressed) < 5000 && !Main.MainChat.Focused
+#if !NON_INTERACTIVE
+                && !Main.MainMenu.MenuPool.AreAnyVisible
+#endif
+                )
             {
                 Function.Call(Hash.DRAW_SCALEFORM_MOVIE, MainScaleform.Handle, 0.122f, 0.3f, 0.28f, 0.6f, 255, 255, 255, 255, 0);
             }


### PR DESCRIPTION
The interface static class will be used from 3rd party mods to
initiate, close and configure the connection. The project can be
compiled with the NON_INTERACTIVE copiler flag to remove the menus
and leave only the interface as a controller.
This is an initial implementation, future additions will support
more operations.