### PR TITLE
Allows sending messages only to a group of users

### DIFF
--- a/Client/COOPAPI.cs
+++ b/Client/COOPAPI.cs
@@ -266,10 +266,10 @@ namespace CoopClient
         /// <summary>
         /// Enable or disable the local traffic for this player
         /// </summary>
-        /// <param name="stop"></param>
-        public static void SetLocalTraffic(bool stop)
+        /// <param name="enable"></param>
+        public static void SetLocalTraffic(bool enable)
         {
-            Main.DisableTraffic = stop;
+            Main.DisableTraffic = !enable;
         }
 
 #if DEBUG

--- a/Client/Main.cs
+++ b/Client/Main.cs
@@ -67,7 +67,9 @@ namespace CoopClient
 
             MainSettings = Util.ReadSettings();
             MainNetworking = new Networking();
+#if !NON_INTERACTIVE
             MainMenu = new MenusMain();
+#endif
             MainChat = new Chat();
             Players = new Dictionary<long, EntitiesPlayer>();
             NPCs = new Dictionary<long, EntitiesNpc>();

--- a/Client/Menus/Sub/Servers.cs
+++ b/Client/Menus/Sub/Servers.cs
@@ -105,11 +105,11 @@ namespace CoopClient.Menus.Sub
                         MainMenu.Visible = false;
 
                         Main.MainNetworking.DisConnectFromServer(address);
-
+#if !NON_INTERACTIVE
                         Main.MainMenu.ServerIpItem.AltTitle = address;
 
                         Main.MainMenu.MainMenu.Visible = true;
-
+#endif
                         Main.MainSettings.LastServerAddress = address;
                         Util.SaveSettings();
                     }

--- a/Server/Server.cs
+++ b/Server/Server.cs
@@ -166,9 +166,10 @@ namespace CoopServer
             {
                 try
                 {
-                    Logging.Info("Loading resource...");
+                    string resourcepath = AppDomain.CurrentDomain.BaseDirectory + "resources" + Path.DirectorySeparatorChar + MainSettings.Resource + ".dll";
+                    Logging.Info($"Loading resource {resourcepath}...");
 
-                    Assembly asm = Assembly.LoadFrom(AppDomain.CurrentDomain.BaseDirectory + "resources" + Path.DirectorySeparatorChar + MainSettings.Resource + ".dll");
+                    Assembly asm = Assembly.LoadFrom(resourcepath);
                     Type[] types = asm.GetExportedTypes();
                     IEnumerable<Type> validTypes = types.Where(t => !t.IsInterface && !t.IsAbstract).Where(t => typeof(ServerScript).IsAssignableFrom(t));
                     Type[] enumerable = validTypes as Type[] ?? validTypes.ToArray();

--- a/Server/ServerScript.cs
+++ b/Server/ServerScript.cs
@@ -207,10 +207,19 @@ namespace CoopServer
         #endregion
 
         #region FUNCTIONS
-        public static void SendModPacketToAll(string mod, byte customID, byte[] bytes)
+        public static void SendModPacketToAll(string mod, byte customID, byte[] bytes, List<long> playerIdList = null)
         {
             try
             {
+                List<NetConnection> connections;
+                if (playerIdList == null)
+                {
+                    connections = Server.MainNetServer.Connections;
+                }
+                else
+                {
+                    connections = Server.MainNetServer.Connections.FindAll(c => playerIdList.Contains(c.RemoteUniqueIdentifier));
+                }
                 NetOutgoingMessage outgoingMessage = Server.MainNetServer.CreateMessage();
                 new ModPacket()
                 {
@@ -220,7 +229,7 @@ namespace CoopServer
                     CustomPacketID = customID,
                     Bytes = bytes
                 }.PacketToNetOutGoingMessage(outgoingMessage);
-                Server.MainNetServer.SendMessage(outgoingMessage, Server.MainNetServer.Connections, NetDeliveryMethod.ReliableOrdered, (int)ConnectionChannel.Mod);
+                Server.MainNetServer.SendMessage(outgoingMessage, connections, NetDeliveryMethod.ReliableOrdered, (int)ConnectionChannel.Mod);
                 Server.MainNetServer.FlushSendQueue();
             }
             catch (Exception e)
@@ -285,7 +294,7 @@ namespace CoopServer
             return Server.Clients.Find(x => x.Player.Username.ToLower() == username.ToLower());
         }
 
-        public static void SendChatMessageToAll(string message, string username = "Server")
+        public static void SendChatMessageToAll(string message, string username = "Server", List<long> playerIdList = null)
         {
             try
             {
@@ -294,13 +303,22 @@ namespace CoopServer
                     return;
                 }
 
+                List<NetConnection> connections;
+                if (playerIdList == null)
+                {
+                    connections = Server.MainNetServer.Connections;
+                }
+                else
+                {
+                    connections = Server.MainNetServer.Connections.FindAll(c => playerIdList.Contains(c.RemoteUniqueIdentifier));
+                }
                 NetOutgoingMessage outgoingMessage = Server.MainNetServer.CreateMessage();
                 new ChatMessagePacket()
                 {
                     Username = username,
                     Message = message
                 }.PacketToNetOutGoingMessage(outgoingMessage);
-                Server.MainNetServer.SendMessage(outgoingMessage, Server.MainNetServer.Connections, NetDeliveryMethod.ReliableOrdered, (int)ConnectionChannel.Chat);
+                Server.MainNetServer.SendMessage(outgoingMessage, connections, NetDeliveryMethod.ReliableOrdered, (int)ConnectionChannel.Chat);
             }
             catch (Exception e)
             {

--- a/Server/ServerScript.cs
+++ b/Server/ServerScript.cs
@@ -207,18 +207,18 @@ namespace CoopServer
         #endregion
 
         #region FUNCTIONS
-        public static void SendModPacketToAll(string mod, byte customID, byte[] bytes, List<long> playerIdList = null)
+        public static void SendModPacketToAll(string mod, byte customID, byte[] bytes, List<long> netHandleList = null)
         {
             try
             {
                 List<NetConnection> connections;
-                if (playerIdList == null)
+                if (netHandleList == null)
                 {
                     connections = Server.MainNetServer.Connections;
                 }
                 else
                 {
-                    connections = Server.MainNetServer.Connections.FindAll(c => playerIdList.Contains(c.RemoteUniqueIdentifier));
+                    connections = Server.MainNetServer.Connections.FindAll(c => netHandleList.Contains(c.RemoteUniqueIdentifier));
                 }
                 NetOutgoingMessage outgoingMessage = Server.MainNetServer.CreateMessage();
                 new ModPacket()
@@ -294,7 +294,7 @@ namespace CoopServer
             return Server.Clients.Find(x => x.Player.Username.ToLower() == username.ToLower());
         }
 
-        public static void SendChatMessageToAll(string message, string username = "Server", List<long> playerIdList = null)
+        public static void SendChatMessageToAll(string message, string username = "Server", List<long> netHandleList = null)
         {
             try
             {
@@ -304,13 +304,13 @@ namespace CoopServer
                 }
 
                 List<NetConnection> connections;
-                if (playerIdList == null)
+                if (netHandleList == null)
                 {
                     connections = Server.MainNetServer.Connections;
                 }
                 else
                 {
-                    connections = Server.MainNetServer.Connections.FindAll(c => playerIdList.Contains(c.RemoteUniqueIdentifier));
+                    connections = Server.MainNetServer.Connections.FindAll(c => netHandleList.Contains(c.RemoteUniqueIdentifier));
                 }
                 NetOutgoingMessage outgoingMessage = Server.MainNetServer.CreateMessage();
                 new ChatMessagePacket()


### PR DESCRIPTION
In some circumstances (like proximity, missions...) we may want
to target messages to only a sub set of all the users connected
to the server. Adding this optional parameter to SendModPacketToAll
and SendChatMessageToAll allows that while being backwards
compatible with the API
Fixes some problems introduced in the non interactive mode
Changes the SetLocalTraffic parameter to make it more readable
so now SetLocalTraffic(true) means to ENABLE local traffic while
SetLocalTraffic(false) means DISABLE local traffic