### PR TITLE
Fixes copy paste error

### DIFF
--- a/Client/Packets.cs
+++ b/Client/Packets.cs
@@ -245,7 +245,7 @@ namespace CoopClient
             NetHandle = reader.ReadLong();
 
             // Read Target
-            NetHandle = reader.ReadLong();
+            Target = reader.ReadLong();
 
             // Read Mod
             int modLength = reader.ReadInt();

--- a/Server/Packets.cs
+++ b/Server/Packets.cs
@@ -228,7 +228,7 @@ namespace CoopServer
             NetHandle = reader.ReadLong();
 
             // Read Target
-            NetHandle = reader.ReadLong();
+            Target = reader.ReadLong();
 
             // Read Mod
             int modLength = reader.ReadInt();


### PR DESCRIPTION
NetIncomingMessageToPacket was overwriting the
NetHandle with the value of the Target and this was making
the from Handle in the messages processed by the resources
to be zero.