### PR TITLE
Adds logging to disconnection to help debugging

### DIFF
--- a/Client/Networking.cs
+++ b/Client/Networking.cs
@@ -170,7 +170,7 @@ namespace CoopClient
                                     catch (Exception ex)
                                     {
                                         GTA.UI.Notification.Show(ex.Message);
-                                        Client.Disconnect(ex.Message);
+                                        Client.Disconnect($"Packet Type:{packetType} Error:{ex.Message}");
                                     }
                                 }
                                 break;
@@ -189,7 +189,7 @@ namespace CoopClient
                                     catch (Exception ex)
                                     {
                                         GTA.UI.Notification.Show(ex.Message);
-                                        Client.Disconnect(ex.Message);
+                                        Client.Disconnect($"Packet Type:{packetType} Error:{ex.Message}");
                                     }
                                 }
                                 break;
@@ -208,7 +208,7 @@ namespace CoopClient
                                     catch (Exception ex)
                                     {
                                         GTA.UI.Notification.Show(ex.Message);
-                                        Client.Disconnect(ex.Message);
+                                        Client.Disconnect($"Packet Type:{packetType} Error:{ex.Message}");
                                     }
                                 }
                                 break;
@@ -227,7 +227,7 @@ namespace CoopClient
                                     catch (Exception ex)
                                     {
                                         GTA.UI.Notification.Show(ex.Message);
-                                        Client.Disconnect(ex.Message);
+                                        Client.Disconnect($"Packet Type:{packetType} Error:{ex.Message}");
                                     }
                                 }
                                 break;
@@ -246,7 +246,7 @@ namespace CoopClient
                                     catch (Exception ex)
                                     {
                                         GTA.UI.Notification.Show(ex.Message);
-                                        Client.Disconnect(ex.Message);
+                                        Client.Disconnect($"Packet Type:{packetType} Error:{ex.Message}");
                                     }
                                 }
                                 break;
@@ -265,7 +265,7 @@ namespace CoopClient
                                     catch (Exception ex)
                                     {
                                         GTA.UI.Notification.Show(ex.Message);
-                                        Client.Disconnect(ex.Message);
+                                        Client.Disconnect($"Packet Type:{packetType} Error:{ex.Message}");
                                     }
                                 }
                                 break;
@@ -284,7 +284,7 @@ namespace CoopClient
                                     catch (Exception ex)
                                     {
                                         GTA.UI.Notification.Show(ex.Message);
-                                        Client.Disconnect(ex.Message);
+                                        Client.Disconnect($"Packet Type:{packetType} Error:{ex.Message}");
                                     }
                                 }
                                 break;
@@ -309,7 +309,7 @@ namespace CoopClient
                                     catch (Exception ex)
                                     {
                                         GTA.UI.Notification.Show(ex.Message);
-                                        Client.Disconnect(ex.Message);
+                                        Client.Disconnect($"Packet Type:{packetType} Error:{ex.Message}");
                                     }
                                 }
                                 break;
@@ -328,7 +328,7 @@ namespace CoopClient
                                     catch (Exception ex)
                                     {
                                         GTA.UI.Notification.Show(ex.Message);
-                                        Client.Disconnect(ex.Message);
+                                        Client.Disconnect($"Packet Type:{packetType} Error:{ex.Message}");
                                     }
                                 }
                                 break;
@@ -347,7 +347,7 @@ namespace CoopClient
                                     catch (Exception ex)
                                     {
                                         GTA.UI.Notification.Show(ex.Message);
-                                        Client.Disconnect(ex.Message);
+                                        Client.Disconnect($"Packet Type:{packetType} Error:{ex.Message}");
                                     }
                                 }
                                 break;
@@ -369,7 +369,7 @@ namespace CoopClient
                                     catch (Exception ex)
                                     {
                                         GTA.UI.Notification.Show(ex.Message);
-                                        Client.Disconnect(ex.Message);
+                                        Client.Disconnect($"Packet Type:{packetType} Error:{ex.Message}");
                                     }
                                 }
                                 break;
@@ -388,7 +388,7 @@ namespace CoopClient
                                     catch (Exception ex)
                                     {
                                         GTA.UI.Notification.Show(ex.Message);
-                                        Client.Disconnect(ex.Message);
+                                        Client.Disconnect($"Packet Type:{packetType} Error:{ex.Message}");
                                     }
                                 }
                                 break;
@@ -407,7 +407,7 @@ namespace CoopClient
                                     catch (Exception ex)
                                     {
                                         GTA.UI.Notification.Show(ex.Message);
-                                        Client.Disconnect(ex.Message);
+                                        Client.Disconnect($"Packet Type:{packetType} Error:{ex.Message}");
                                     }
                                 }
                                 break;
@@ -417,16 +417,14 @@ namespace CoopClient
                                     {
                                         int len = message.ReadInt32();
                                         byte[] data = message.ReadBytes(len);
-
                                         Packets.Mod packet = new Packets.Mod();
                                         packet.NetIncomingMessageToPacket(data);
-
                                         COOPAPI.ModPacketReceived(packet.NetHandle, packet.Name, packet.CustomPacketID, packet.Bytes);
                                     }
                                     catch (Exception ex)
                                     {
                                         GTA.UI.Notification.Show(ex.Message);
-                                        Client.Disconnect(ex.Message);
+                                        Client.Disconnect($"Packet Type:{packetType} Error:{ex.Message}");
                                     }
                                 }
                                 break;

--- a/Server/Server.cs
+++ b/Server/Server.cs
@@ -287,7 +287,7 @@ namespace CoopServer
                                         }
                                         catch (Exception e)
                                         {
-                                            message.SenderConnection.Disconnect(e.Message);
+                                            DisconnectAndLog(message.SenderConnection, type, e);
                                         }
                                     }
                                     break;
@@ -305,7 +305,7 @@ namespace CoopServer
                                         }
                                         catch (Exception e)
                                         {
-                                            message.SenderConnection.Disconnect(e.Message);
+                                            DisconnectAndLog(message.SenderConnection, type, e);
                                         }
                                     }
                                     break;
@@ -323,7 +323,7 @@ namespace CoopServer
                                         }
                                         catch (Exception e)
                                         {
-                                            message.SenderConnection.Disconnect(e.Message);
+                                            DisconnectAndLog(message.SenderConnection, type, e);
                                         }
                                     }
                                     break;
@@ -341,7 +341,7 @@ namespace CoopServer
                                         }
                                         catch (Exception e)
                                         {
-                                            message.SenderConnection.Disconnect(e.Message);
+                                            DisconnectAndLog(message.SenderConnection, type, e);
                                         }
                                     }
                                     break;
@@ -359,7 +359,7 @@ namespace CoopServer
                                         }
                                         catch (Exception e)
                                         {
-                                            message.SenderConnection.Disconnect(e.Message);
+                                            DisconnectAndLog(message.SenderConnection, type, e);
                                         }
                                     }
                                     break;
@@ -379,7 +379,7 @@ namespace CoopServer
                                             }
                                             catch (Exception e)
                                             {
-                                                message.SenderConnection.Disconnect(e.Message);
+                                                DisconnectAndLog(message.SenderConnection, type, e);
                                             }
                                         }
                                         else
@@ -404,7 +404,7 @@ namespace CoopServer
                                             }
                                             catch (Exception e)
                                             {
-                                                message.SenderConnection.Disconnect(e.Message);
+                                                DisconnectAndLog(message.SenderConnection, type, e);
                                             }
                                         }
                                         else
@@ -435,7 +435,7 @@ namespace CoopServer
                                         }
                                         catch (Exception e)
                                         {
-                                            message.SenderConnection.Disconnect(e.Message);
+                                            DisconnectAndLog(message.SenderConnection, type, e);
                                         }
                                     }
                                     break;
@@ -487,7 +487,7 @@ namespace CoopServer
                                             }
                                             catch (Exception e)
                                             {
-                                                message.SenderConnection.Disconnect(e.Message);
+                                                DisconnectAndLog(message.SenderConnection, type, e);
                                             }
                                         }
                                         else
@@ -550,6 +550,14 @@ namespace CoopServer
                 // Sleep for 1 second
                 Thread.Sleep(1000);
             }
+        }
+
+        private void DisconnectAndLog(NetConnection senderConnection, byte type, Exception e)
+        {
+            Logging.Error($"Error receiving a packet of type {type}");
+            Logging.Error(e.Message);
+            Logging.Error(e.StackTrace);
+            senderConnection.Disconnect(e.Message);
         }
 
         #region -- PLAYER --

--- a/Server/Server.cs
+++ b/Server/Server.cs
@@ -576,7 +576,7 @@ namespace CoopServer
                 local.Deny("Username is empty or contains spaces!");
                 return;
             }
-            if (packet.Username.Any(p => !char.IsLetterOrDigit(p)))
+            if (packet.Username.Any(p => !char.IsLetterOrDigit(p) && !(p == '_') && !(p=='-')))
             {
                 local.Deny("Username contains special chars!");
                 return;

--- a/Server/ServerScript.cs
+++ b/Server/ServerScript.cs
@@ -303,18 +303,23 @@ namespace CoopServer
                 List<NetConnection> connections = netHandleList == null
                     ? Server.MainNetServer.Connections
                     : Server.MainNetServer.Connections.FindAll(c => netHandleList.Contains(c.RemoteUniqueIdentifier));
-
-                NetOutgoingMessage outgoingMessage = Server.MainNetServer.CreateMessage();
-                new Packets.Mod()
+                // A resource can be calling this function on disconnect of the last player in the server and we will
+                // get an empty connection list, make sure connections has at least one handle in it
+                if (connections.Count > 0)
                 {
-                    NetHandle = 0,
-                    Target = 0,
-                    Name = modName,
-                    CustomPacketID = customID,
-                    Bytes = bytes
-                }.PacketToNetOutGoingMessage(outgoingMessage);
-                Server.MainNetServer.SendMessage(outgoingMessage, connections, NetDeliveryMethod.ReliableOrdered, (byte)ConnectionChannel.Mod);
-                Server.MainNetServer.FlushSendQueue();
+                    NetOutgoingMessage outgoingMessage = Server.MainNetServer.CreateMessage();
+                    new Packets.Mod()
+                    {
+                        NetHandle = 0,
+                        Target = 0,
+                        Name = modName,
+                        CustomPacketID = customID,
+                        Bytes = bytes
+                    }.PacketToNetOutGoingMessage(outgoingMessage);
+                    Logging.Debug($"SendModPacketToAll recipients list {connections.Count}");
+                    Server.MainNetServer.SendMessage(outgoingMessage, connections, NetDeliveryMethod.ReliableOrdered, (byte)ConnectionChannel.Mod);
+                    Server.MainNetServer.FlushSendQueue();
+                }
             }
             catch (Exception e)
             {


### PR DESCRIPTION
When the user is disconnected from a malformed or wrong message
it is now logged in the server for debugging purposes.
If the disconnection comes from the client itself, the reason
of disconnection will contain the offending message type.